### PR TITLE
fix another broken link in README.md

### DIFF
--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -114,7 +114,7 @@ Note that `ttl` is lowered to 60 seconds in both cases just for demo purposes.
 
 
 ### 8. Start spiffe-helper
-Start spiffe-helper using this example [configuration file](examples/postgresql/helper.conf) with the `postgres` user:
+Start spiffe-helper using this example [configuration file](helper.conf) with the `postgres` user:
 
 ```
 sudo -u postgres ./spiffe-helper -config examples/postgresql/helper.conf


### PR DESCRIPTION
Fix a broken link in the postgresql example's README.md file