### PR TITLE
Update Config Files with SPIRE Agent Default Socket Path and Fix `README.md` Table Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ If `-config` is not specified, the default value `helper.conf` is assumed.
 ## Configuration
 The configuration file is an [HCL](https://github.com/hashicorp/hcl) formatted file that defines the following configurations:
 
- | Configuration               | Description                                                                                                    | Example Value        |
- |-----------------------------|----------------------------------------------------------------------------------------------------------------| -------------------- |
- |`agent_address`              | Socket address of SPIRE Agent.                                                                                 | `"/tmp/agent.sock"`  |
- |`cmd`                        | The path to the process to launch.                                                                             | `"ghostunnel"`       |
- |`cmd_args`                   | The arguments of the process to launch.                                                                        | `"server --listen localhost:8002 --target localhost:8001--keystore certs/svid_key.pem --cacert certs/svid_bundle.pem --allow-uri-san spiffe://example.org/Database"` |
- |`cert_dir`                   | Directory name to store the fetched certificates. This directory must be created previously.                   | `"certs"`            |
- |`add_intermediates_to_bundle`| Add intermediate certificates into Bundle file instead of SVID file.                                           | `true`               |
- |`renew_signal`               | The signal that the process to be launched expects to reload the certificates. It is not supported on Windows. | `"SIGUSR1"`          |
- |`svid_file_name`             | File name to be used to store the X.509 SVID public certificate in PEM format.                                 | `"svid.pem"`         |
- |`svid_key_file_name`         | File name to be used to store the X.509 SVID private key and public certificate in PEM format.                 | `"svid_key.pem"`     |
- |`svid_bundle_file_name`      | File name to be used to store the X.509 SVID Bundle in PEM format.                                             | `"svid_bundle.pem"`  |
- |`jwt_audience`               | JWT SVID audience.                                                                                             | `"your-audience"`    |
- |`jwt_svid_file_name`         | File name to be used to store JWT SVID in Base64-encoded string.                                               | `"jwt_svid.token"`   |
- |`jwt_bundle_file_name`       | File name to be used to store JWT Bundle in JSON format.                                                       | `"jwt_bundle.json"`  |
+ | Configuration                 | Description                                                                                                    | Example Value                                                                                                                                                        |
+ |-------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | `agent_address`               | Socket address of SPIRE Agent.                                                                                 | `"/tmp/agent.sock"`                                                                                                                                                  |
+ | `cmd`                         | The path to the process to launch.                                                                             | `"ghostunnel"`                                                                                                                                                       |
+ | `cmd_args`                    | The arguments of the process to launch.                                                                        | `"server --listen localhost:8002 --target localhost:8001--keystore certs/svid_key.pem --cacert certs/svid_bundle.pem --allow-uri-san spiffe://example.org/Database"` |
+ | `cert_dir`                    | Directory name to store the fetched certificates. This directory must be created previously.                   | `"certs"`                                                                                                                                                            |
+ | `add_intermediates_to_bundle` | Add intermediate certificates into Bundle file instead of SVID file.                                           | `true`                                                                                                                                                               |
+ | `renew_signal`                | The signal that the process to be launched expects to reload the certificates. It is not supported on Windows. | `"SIGUSR1"`                                                                                                                                                          |
+ | `svid_file_name`              | File name to be used to store the X.509 SVID public certificate in PEM format.                                 | `"svid.pem"`                                                                                                                                                         |
+ | `svid_key_file_name`          | File name to be used to store the X.509 SVID private key and public certificate in PEM format.                 | `"svid_key.pem"`                                                                                                                                                     |
+ | `svid_bundle_file_name`       | File name to be used to store the X.509 SVID Bundle in PEM format.                                             | `"svid_bundle.pem"`                                                                                                                                                  |
+ | `jwt_audience`                | JWT SVID audience.                                                                                             | `"your-audience"`                                                                                                                                                    |
+ | `jwt_svid_file_name`          | File name to be used to store JWT SVID in Base64-encoded string.                                               | `"jwt_svid.token"`                                                                                                                                                   |
+ | `jwt_bundle_file_name`        | File name to be used to store JWT Bundle in JSON format.                                                       | `"jwt_bundle.json"`                                                                                                                                                  |
 
 ### Configuration example
 ```
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 cmd = "ghostunnel"
 cmd_args = "server --listen localhost:8002 --target localhost:8001 --keystore certs/svid_key.pem --cacert certs/svid_bundle.pem --allow-uri-san spiffe://example.org/Database"
 cert_dir = "certs"

--- a/examples/mysql/helper.conf
+++ b/examples/mysql/helper.conf
@@ -1,5 +1,5 @@
 # SPIRE agent unix socket path
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 
 # mysql binary path
 cmd = "/usr/bin/mysql"

--- a/examples/mysql/spire-agent.conf
+++ b/examples/mysql/spire-agent.conf
@@ -3,7 +3,7 @@ agent {
     log_level = "DEBUG"
     server_address = "127.0.0.1"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
+    socket_path ="/tmp/spire-agent/public/api.sock"
     trust_bundle_path = "./conf/agent/dummy_root_ca.crt"
     trust_domain = "example.org"
 }

--- a/examples/postgresql/helper.conf
+++ b/examples/postgresql/helper.conf
@@ -19,7 +19,7 @@
 #
 
 # SPIRE agent unix socket path
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 
 # psql binary path
 cmd = "/usr/bin/psql"

--- a/examples/postgresql/spire-agent.conf
+++ b/examples/postgresql/spire-agent.conf
@@ -3,7 +3,7 @@ agent {
     log_level = "DEBUG"
     server_address = "127.0.0.1"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
+    socket_path ="/tmp/spire-agent/public/api.sock"
     trust_bundle_path = "./conf/agent/dummy_root_ca.crt"
     trust_domain = "example.org"
 }

--- a/helper.conf
+++ b/helper.conf
@@ -1,4 +1,4 @@
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 cmd = ""
 cmd_args = ""
 cert_dir = "certs"

--- a/helper_envoy.conf
+++ b/helper_envoy.conf
@@ -1,4 +1,4 @@
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 cmd = "hot-restarter.py"
 cmd_args = "start_envoy.sh"
 cert_dir = "certs"

--- a/helper_ghostunnel.conf
+++ b/helper_ghostunnel.conf
@@ -1,4 +1,4 @@
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 cmd = "ghostunnel"
 cmd_args = "server --listen localhost:8002 --target localhost:8001 --keystore certs/svid_key.pem --cacert certs/svid_bundle.pem --allow-uri-san spiffe://example.org/Database"
 cert_dir = "certs"

--- a/pkg/sidecar/config_test.go
+++ b/pkg/sidecar/config_test.go
@@ -14,7 +14,7 @@ func TestParseConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	expectedAgentAddress := "/tmp/agent.sock"
+	expectedAgentAddress := "/tmp/spire-agent/public/api.sock"
 	expectedCmd := "hot-restarter.py"
 	expectedCmdArgs := "start_envoy.sh"
 	expectedCertDir := "certs"

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -199,16 +199,16 @@ func TestDefaultAgentAddress(t *testing.T) {
 	assert.Equal(t, spiffeSidecar.config.AgentAddress, "/tmp/spire-agent/public/api.sock")
 }
 func TestEnvAgentAddress(t *testing.T) {
-	os.Setenv("SPIRE_AGENT_ADDRESS", "/tmp/agent.sock")
+	os.Setenv("SPIRE_AGENT_ADDRESS", "/tmp/spire-agent/public/api.sock")
 	log, _ := test.NewNullLogger()
 	spiffeSidecar, err := New("../../test/sidecar/config/helper.conf", log)
 	require.NoError(t, err)
-	assert.Equal(t, spiffeSidecar.config.AgentAddress, "/tmp/agent.sock")
+	assert.Equal(t, spiffeSidecar.config.AgentAddress, "/tmp/spire-agent/public/api.sock")
 }
 
 func TestAgentAddress(t *testing.T) {
 	// This test is used to verify that we get the agent_address of the .conf file instead of the ENV value, if we have both
-	os.Setenv("SPIRE_AGENT_ADDRESS", "/tmp/agent.sock")
+	os.Setenv("SPIRE_AGENT_ADDRESS", "/tmp/spire-agent/public/api.sock")
 	log, _ := test.NewNullLogger()
 	spiffeSidecar, err := New("../../test/sidecar/configWithAddress/helper.conf", log)
 	require.NoError(t, err)

--- a/test/fixture/config/helper.conf
+++ b/test/fixture/config/helper.conf
@@ -1,4 +1,4 @@
-agent_address = "/tmp/agent.sock"
+agent_address = "/tmp/spire-agent/public/api.sock"
 cmd = "hot-restarter.py"
 cmd_args = "start_envoy.sh"
 cert_dir = "certs"


### PR DESCRIPTION
This PR includes updates to all configuration files, changing the SPIRE agent socket path to the default `"/tmp/spire-agent/public/api.sock"`. Additionally, adjustments have been made to fix the formatting of the table in the `README.md` file.