### PR TITLE
Setup nightly build

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -1,0 +1,39 @@
+name: Nightly Build
+on:
+  schedule:
+    # Random minute number to avoid GH scheduler stampede
+    - cron: '37 21 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  build-and-publish-images:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+      - name: Build image
+        run: make docker-build
+      - name: Log in to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push images
+        run: ./.github/workflows/scripts/push-images.sh nightly

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+##
+## USAGE: __PROG__
+##
+## "__PROG__" publishes images to a registry.
+##
+## Usage example(s):
+##   ./__PROG__ 1.5.2
+##   ./__PROG__ v1.5.2
+##   ./__PROG__ refs/tags/v1.5.2
+##
+## Commands
+## - ./__PROG__ <version>    pushes images to the registry using given version.
+
+set -e
+
+function usage {
+  grep '^##' "$0" | sed -e 's/^##//' -e "s/__PROG__/$me/" >&2
+}
+
+function normalize_path {
+  # Remove all /./ sequences.
+  local path=${1//\/.\//\/}
+  local npath
+  # Remove first dir/.. sequence.
+  npath="${path//[^\/][^\/]*\/\.\.\//}"
+  # Remove remaining dir/.. sequence.
+  while [[ $npath != "$path" ]] ; do
+    path=$npath
+    npath="${path//[^\/][^\/]*\/\.\.\//}"
+  done
+  echo "$path"
+}
+
+me=$(basename "$0")
+BASEDIR=$(dirname "$0")
+ROOTDIR="$(normalize_path "$BASEDIR/../../../")"
+
+version="$1"
+# remove the git tag prefix
+# Push the images using the version tag (without the "v" prefix).
+# Also strips the refs/tags part if the GITHUB_REF variable is used.
+version="${version#refs/tags/v}"
+version="${version#v}"
+
+if [ -z "${version}" ]; then
+    usage
+    echo "version not provided!" 1>&2
+    exit 1
+fi
+
+image=spiffe-helper
+org_name=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
+org_name="${org_name:-spiffe}" # default to spiffe in case ran outside of GitHub actions
+registry=ghcr.io/${org_name}
+image_to_push="${registry}/${image}:${version}"
+oci_dir="ocidir://${ROOTDIR}oci/${image}"
+
+echo "Pushing ${image_to_push}."
+regctl image import "${oci_dir}" "${image}-image.tar"
+regctl image copy "${oci_dir}" "${image_to_push}"


### PR DESCRIPTION
Sets up a nightly docker build same as spiffe repos. Code is mostly copied from controller manager.