### PR TITLE
docs: readme fix, use jwt_svids instead of jwt_svid_file_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ renew_signal = "SIGUSR1"
 svid_file_name = "svid.pem"
 svid_key_file_name = "svid_key.pem"
 svid_bundle_file_name = "svid_bundle.pem"
-jwt_audience = "your-audience"
-jwt_svid_file_name = "jwt.token"
+jwt_svids = [{jwt_audience="your-audience", jwt_svid_file_name="jwt_svid.token"}]
 jwt_bundle_file_name = "bundle.json"
 ```
 
@@ -55,7 +54,6 @@ cert_dir = "certs"
 svid_file_name = "svid.pem"
 svid_key_file_name = "svid_key.pem"
 svid_bundle_file_name = "svid_bundle.pem"
-jwt_audience = "your-audience"
-jwt_svid_file_name = "jwt.token"
+jwt_svids = [{jwt_audience="your-audience", jwt_svid_file_name="jwt_svid.token"}]
 jwt_bundle_file_name = "bundle.json"
 ```


### PR DESCRIPTION
the jwt config vars have changed, 
the documentation in the stanza above is correct but the examples still reference the older config options
this 