### PR TITLE
Write private key in accordance with Asymmetric Key Packages RFC

### DIFF
--- a/pkg/disk/x509.go
+++ b/pkg/disk/x509.go
@@ -88,7 +88,7 @@ func writeCerts(file string, certs []*x509.Certificate) error {
 // formats as PEM, and writes it to file
 func writeKey(file string, data []byte) error {
 	b := &pem.Block{
-		Type:  "EC PRIVATE KEY",
+		Type:  "PRIVATE KEY",
 		Bytes: data,
 	}
 


### PR DESCRIPTION
The key is marshaled using [MarshalPKCS8PrivateKey](https://pkg.go.dev/crypto/x509#MarshalPKCS8PrivateKey) which suggests the "PRIVATE KEY" PEM block type, and [Asymmetric Key Packages RFC](https://datatracker.ietf.org/doc/html/rfc5958) states:
> When .p8 files are PEM encoded they use the .pem file extension. PEM encoding is ... Base64 encoding, see Section 4 of [RFC4648], of the DER-encoded PrivateKeyInfo sandwiched between:
>   -----BEGIN PRIVATE KEY-----
>   -----END PRIVATE KEY-----