### PR TITLE
Fix Dockerfile after config reorg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy the go source
-COPY cmd/spiffe-helper/main.go cmd/spiffe-helper/main.go
+COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # xx is a helper for cross-compilation


### PR DESCRIPTION
Merging https://github.com/spiffe/spiffe-helper/pull/146 broke the Dockerfile. We added new files under `cmd/`.