### PR TITLE
Use `go-version-file` in Setup go actions

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -4,8 +4,6 @@ on:
     # Random minute number to avoid GH scheduler stampede
     - cron: '37 21 * * *'
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.22.1
 
 jobs:
   build-and-publish-images:
@@ -22,7 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,8 +2,6 @@ name: PR Build
 on:
   pull_request: {}
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.22.1
 permissions:
   contents: read
 
@@ -21,7 +19,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Setup dep cache
         uses: actions/cache@v4
         with:
@@ -44,7 +42,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Load cached deps
         uses: actions/cache@v4
         with:
@@ -78,7 +76,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Load cached deps
         uses: actions/cache@v4
         with:
@@ -144,7 +142,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Load cached deps
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -4,9 +4,6 @@ on:
     tags:
       - 'v[0-9].[0-9]+.[0-9]+'
 
-env:
-  GO_VERSION: 1.22.1
-
 jobs:
   build-matrix:
     name: Build matrix
@@ -55,7 +52,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Build artifact
         run: make build
       - name: Compress artifact


### PR DESCRIPTION
**Utilize go-version-file in GitHub Actions for Go Setup:**

This PR updates our GitHub Actions by integrating `go-version-file` to specify the Go version during the setup process. This change ensures that the Go environment is consistent with the version defined in the project configuration.