### PR TITLE
add missing files to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy the go source
-COPY cmd/spiffe-helper/main.go cmd/spiffe-helper/main.go
+COPY cmd/spiffe-helper/ cmd/spiffe-helper/
 COPY pkg/ pkg/
 
 # xx is a helper for cross-compilation


### PR DESCRIPTION
Looks like commit eb7a20 broke the docker build (via theDockerfile). Previously only main.go was COPY'd in the docker file. 

Fix is simple, just COPY the whole cmd/spiffe-helper directory rather than just the main.go. 

Looks like the nightly builds have been failing. One suggestion might to add building the docker image to the pr_build tests. I can take a stab at this if desired, I'd mostly just cut and paste from the nightly build minus the pushing. 

Thanks,
Geoff