### PR TITLE
Update linter to 1.60.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,28 +2,31 @@ run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 10m
 
-  skip-dirs:
+issues:
+  exclude-dirs:
     - testdata$
     - test/mock
-
-  skip-files:
+  exclude-files:
     - ".*\\.pb\\.go"
 
 linters:
   enable:
     - bodyclose
-    - depguard
+    - dupword
     - durationcheck
     - errorlint
+    - gocritic
+    - gofmt
     - goimports
-    - revive
     - gosec
     - misspell
     - nakedret
+    - nilerr
+    - prealloc
+    - revive
     - unconvert
     - unparam
     - whitespace
-    - gocritic
 
 linters-settings:
   revive:

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ else
 endif
 go_path := PATH="$(go_bin_dir):$(PATH)"
 
-golangci_lint_version = v1.52.2
+golangci_lint_version = v1.60.3
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 golangci_lint_cache = $(golangci_lint_dir)/cache

--- a/pkg/disk/json.go
+++ b/pkg/disk/json.go
@@ -36,7 +36,7 @@ func WriteJWTBundleSet(jwkSet *jwtbundle.Set, dir string, jwtBundleFilename stri
 func WriteJWTSVID(jwtSVID *jwtsvid.SVID, dir, jwtSVIDFilename string) error {
 	filePath := path.Join(dir, jwtSVIDFilename)
 
-	return os.WriteFile(filePath, []byte(jwtSVID.Marshal()), os.ModePerm)
+	return os.WriteFile(filePath, []byte(jwtSVID.Marshal()), 0600)
 }
 
 func writeJSON(certs map[string]any, dir, filename string) error {
@@ -47,5 +47,5 @@ func writeJSON(certs map[string]any, dir, filename string) error {
 
 	filePath := path.Join(dir, filename)
 
-	return os.WriteFile(filePath, file, os.ModePerm)
+	return os.WriteFile(filePath, file, 0600)
 }


### PR DESCRIPTION
- Update to latest version of golangci-lint.
- Remove depguard linter, throws a lot of errors. Same was done on spire repo.
- Fix file write permissions