### PR TITLE
Add docker build to release workflow

### DIFF
--- a/.github/tests/it/docker-compose.yaml
+++ b/.github/tests/it/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: ghcr.io/spiffe/spire-server:1.7.0

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -78,6 +78,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -45,6 +45,7 @@ jobs:
   build:
     name: build (linux)
     runs-on: ubuntu-22.04
+    needs: integration-tests
 
     steps:
       - name: Checkout
@@ -53,15 +54,23 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build artifact
         run: make build
+      - name: Build docker artifact
+        run: make docker-build
       - name: Compress artifact
         run: tar -czvf spiffe-helper-${{ github.ref_name }}.tar.gz spiffe-helper
       - name: Archive artifact
         uses: actions/upload-artifact@v4
         with:
           name: spiffe-helper
-          path: spiffe-helper-${{ github.ref_name }}.tar.gz
+          path: |
+            spiffe-helper-${{ github.ref_name }}.tar.gz
+            spiffe-helper-image.tar
 
   release:
     runs-on: ubuntu-22.04
@@ -77,9 +86,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: spiffe-helper
-          path: ./artifact/
+          path: .
+      - name: Log in to GHCR
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+      - name: Push docker image
+        run: ./.github/workflows/scripts/push-images.sh ${{ github.ref_name }}
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Create the release using the version number as the title
-        run: gh release create "${GITHUB_REF#refs/tags/}" ./artifact/spiffe-helper-${{ github.ref_name }}.tar.gz --title "${GITHUB_REF#refs/tags/}"
+        run: gh release create "${GITHUB_REF#refs/tags/}" ./spiffe-helper-${{ github.ref_name }}.tar.gz --title "${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
Builds and pushes container to ghcr.io as part of release workflow. Partially addresses #165 