### PR TITLE
Remove redundant Dockerfile in tests

### DIFF
--- a/.github/tests/it/build.sh
+++ b/.github/tests/it/build.sh
@@ -55,7 +55,8 @@ docker compose exec spire-server ./bin/spire-server entry create \
 # set ups spire agent
 docker compose up spire-agent -d
 
-docker compose build spiffe-helper
+go_version=$(sed -En 's/^go[ ]+([0-9.]+).*/\1/p' ../../../go.mod)
+docker compose build --build-arg go_version=$go_version spiffe-helper
 
 # set ups and postgres-db
 docker compose up postgres-db -d

--- a/.github/tests/it/build.sh
+++ b/.github/tests/it/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 fingerprint () {
 	# calculate the SHA1 digest of the DER bytes of the certificate using the

--- a/.github/tests/it/client/Dockerfile
+++ b/.github/tests/it/client/Dockerfile
@@ -27,5 +27,5 @@ RUN chown client:client \
     /run/client/certs/root.crt
 
 USER root
-COPY --from=it-spiffe-helper /service/spiffe-helper /opt/helper/spiffe-helper
+COPY --from=it-spiffe-helper /spiffe-helper /opt/helper/spiffe-helper
 COPY --from=builder /service/client /opt/go-client/client

--- a/.github/tests/it/docker-compose.yaml
+++ b/.github/tests/it/docker-compose.yaml
@@ -19,7 +19,9 @@ services:
   spiffe-helper:
     build: 
       context: ../../../
-      dockerfile: ./.github/tests/it/spiffe-helper/Dockerfile
+      dockerfile: ./Dockerfile
+      args:
+        - go_version
 
   postgres-db:
     build: postgres

--- a/.github/tests/it/go-server/Dockerfile
+++ b/.github/tests/it/go-server/Dockerfile
@@ -16,5 +16,5 @@ RUN chown go-server:go-server \
     /run/go-server/certs/root.crt
 
 USER root
-COPY --from=it-spiffe-helper /service/spiffe-helper /opt/helper/spiffe-helper
+COPY --from=it-spiffe-helper /spiffe-helper /opt/helper/spiffe-helper
 COPY --from=builder /service/server /opt/go-server/server

--- a/.github/tests/it/mysql/Dockerfile
+++ b/.github/tests/it/mysql/Dockerfile
@@ -10,4 +10,4 @@ RUN touch /var/lib/mysql/server-cert.pem /var/lib/mysql/server-key.pem /var/lib/
 RUN chmod 660 /var/lib/mysql/server-cert.pem /var/lib/mysql/server-key.pem /var/lib/mysql/ca.pem
 
 USER root
-COPY --from=it-spiffe-helper /service/spiffe-helper /opt/helper/spiffe-helper
+COPY --from=it-spiffe-helper /spiffe-helper /opt/helper/spiffe-helper

--- a/.github/tests/it/postgres/Dockerfile
+++ b/.github/tests/it/postgres/Dockerfile
@@ -21,4 +21,4 @@ RUN chmod 700 /var/lib/postgresql/data
 RUN initdb -D /var/lib/postgresql/data
 
 USER root
-COPY --from=it-spiffe-helper /service/spiffe-helper /opt/helper/spiffe-helper
+COPY --from=it-spiffe-helper /spiffe-helper /opt/helper/spiffe-helper

--- a/.github/tests/it/spiffe-helper/Dockerfile
+++ b/.github/tests/it/spiffe-helper/Dockerfile
@@ -1,4 +1,0 @@
-FROM golang:1.22.3-alpine AS spiffe-helper
-COPY ./ /service/
-WORKDIR /service
-RUN go build -tags netgo -a -v -o /service/spiffe-helper ./cmd/spiffe-helper

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -118,7 +118,12 @@ jobs:
       matrix:
        tests: ${{ fromJson(needs.build-matrix.outputs.tests) }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Build containers
         run: ./build.sh
         shell: bash


### PR DESCRIPTION
The integration tests have a dockerfile to build a spiffe-helper container. This was added before we had a proper container build. This diff removes the redundant dockerfile and uses the one in the root of the repo.