### PR TITLE
Upgrade golangci-lint to fix error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ else
 endif
 go_path := PATH="$(go_bin_dir):$(PATH)"
 
-golangci_lint_version = v1.60.3
+golangci_lint_version = v1.62.2
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 golangci_lint_cache = $(golangci_lint_dir)/cache


### PR DESCRIPTION
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.3)