### PR TITLE
Warn when unused ExitWhenReady config option is set

### DIFF
--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -26,7 +26,8 @@ type Config struct {
 	// The directory name to store the x509s and/or JWTs.
 	CertDir string
 
-	// If true, fetches x509 certificate and then exit(0).
+	// Deprecated and ignored. Use DaemonMode in
+	// cmd/spiffe-helper/config/config.go's Config instead.
 	ExitWhenReady bool
 
 	// Permissions to use when writing x509 SVID to disk

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -51,6 +51,9 @@ const (
 
 // New creates a new SPIFFE sidecar
 func New(config *Config) *Sidecar {
+	if config.ExitWhenReady {
+		config.Log.Warn("The ExitWhenReady flag is set but it is deprecated and will be ignored. Use daemon_mode=false instead.")
+	}
 	sidecar := &Sidecar{
 		config:        config,
 		certReadyChan: make(chan struct{}, 1),


### PR DESCRIPTION
The `ExitWhenReady` option is completely unused and ignored.

It is exposed as a public field in the sidecar config, so it's not safe to remove it in case someone might be extending this code. 

Update the comments to indicate that it is ignored, and emit a warning if it is found to be set to true.

```
➜  spiffe-helper git:(warn-exitwhenready-ignored) ✗ make test
go test ./...
?   	github.com/spiffe/spiffe-helper/cmd/spiffe-helper	[no test files]
?   	github.com/spiffe/spiffe-helper/pkg/health	[no test files]
?   	github.com/spiffe/spiffe-helper/test/spiffetest	[no test files]
?   	github.com/spiffe/spiffe-helper/test/util	[no test files]
ok  	github.com/spiffe/spiffe-helper/cmd/spiffe-helper/config	0.006s
ok  	github.com/spiffe/spiffe-helper/pkg/disk	0.015s
ok  	github.com/spiffe/spiffe-helper/pkg/sidecar	0.010s
```