### PR TITLE
Forward spiffe-helper's stdin to the 'cmd' invoked in daemon_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The configuration file is an [HCL](https://github.com/hashicorp/hcl) formatted f
  | `jwt_bundle_file_mode`              | The octal file mode to use when saving a JWT Bundle file.                                                                         | `0600`                                                                                                                                                               |
  | `jwt_svid_file_mode`                | The octal file mode to use when saving a JWT SVID file.                                                                           | `0600`                                                                                                                                                               |
 
+**Notes**:
+
+* If `cmd` is specified, spiffe-helper will connect its `stdin`, `stdout` and
+  `stderr` to that of the command it invokes. If this is not desired, close
+  these file descriptors before invoking spiffe-helper.
+
 ### Health Checks Configuration
 SPIFFE Helper can expose and endpoint that can be used for health checking
 


### PR DESCRIPTION
[Presently it's difficult to use `spiffe-helper` to wrap another command](https://github.com/spiffe/spiffe-helper/issues/249), because:

* it doesn't forward its stdin to the command it runs
* it doesn't write the child command's pid anywhere, nor does it forward signals, so there's no easy way to reliably identify and signal the wrapped process
* it uses a stringified argument list when invoking the child process, which is difficult to reliably and correctly escape for all argument variations

(See related: https://github.com/spiffe/spiffe-helper/pull/243, https://github.com/spiffe/spiffe-helper/pull/244)

This PR makes one step toward making it more practical to use the helper as a wrapper command, by forwarding `stdin` to the `cmd` invoked.

Other improvements are needed to make wrapper use reliable, including

* a way to run the `cmd` one-shot and exit with the `cmd`'s exit code when the cmd exits; and
* safer argument handling that preserves the original argument vector by using a HCL array of args not a string and supports CLI invocation like `spiffe-helper -c some_config.hcl -- my_cmd "my argument" "here"` too.

(WIP for these changes can be seen in this commit: https://github.com/spiffe/spiffe-helper/commit/a69629546cec5f90a07b9a0bb6f830bdca9bb8ca, and notes in this comment: https://github.com/spiffe/spiffe-helper/pull/245#issuecomment-2629577661) 

**WARNING** This PR introduces a corner case behaviour change.

If `spiffe-helper` is invoked in a context where consuming stdin will have an effect on the caller, and it runs a 'cmd' that can optionally consume from stdin but ignores it if stdin is closed, then this change will cause spiffe-helper invocations to consume from stdin that would otherwise go to the caller.
    
E.g. this contrived bash code
    
        echo -n $'a\nb\nc\nd\n' | {
          spiffe-helper -config some_config.hcl & ;
          spiffe_helper_pid=$! ;
          while read -r SOME_VAR ; do
            echo "Got SOME_VAR: ${SOME_VAR}" ;
          done
        }

would have previously echoed one line for each of `a`, `b`, `c`, and `d`. Now, if `spiffe-helper`'s `cmd` configured in `some_config.hcl` consumes stdin if it's attached, it'll instead produce no output (and the unexpectedly connected `stdin` may confuse the `cmd`.)
    
This is an unlikely corner case so this change is being made unconditionally, not gated behind a feature flag or configuration option. If anyone is actually affected by this, they can close the `stdin` file descriptor they pass when invoking `spiffe-helper`, e.g. in bash run `spiffe-helper <&-`.
