### PR TITLE
Remove ExitWhenReady field

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The SPIFFE Helper is a simple utility for fetching X.509 SVID certificates from 
 
 If `-config` is not specified, the default value `helper.conf` is assumed. 
 
-The flag `-exitWhenReady` is also supported.
-
 ## Configuration
 The configuration file is an [HCL](https://github.com/hashicorp/hcl) formatted file that defines the following configurations:
 

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -26,9 +26,6 @@ type Config struct {
 	// The directory name to store the x509s and/or JWTs.
 	CertDir string
 
-	// If true, fetches x509 certificate and then exit(0).
-	ExitWhenReady bool
-
 	// Permissions to use when writing x509 SVID to disk
 	CertFileMode fs.FileMode
 


### PR DESCRIPTION
Per https://github.com/spiffe/spiffe-helper/pull/243#discussion_r1937612176 the -exitWhenReady flag and corresponding ExitWhenReady option were never in a released version. So this obsolete, now-unused field can be deleted without backwards compatibility impact.

The separate PR https://github.com/spiffe/spiffe-helper/pull/243 updates the docs to remove reference to the CLI argument -exitWhenReady.