### PR TITLE
Switch to goreleaser

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -6,34 +6,30 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-and-publish-images:
+  goreleaser:
     runs-on: ubuntu-22.04
-
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-
+    needs: integration-tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install regctl
-        uses: regclient/actions/regctl-installer@main
-      - name: Build image
-        run: make docker-build
+          fetch-depth: 0
       - name: Log in to GHCR
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push images
-        run: ./.github/workflows/scripts/push-images.sh nightly
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean --skip=archive,publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REPO: ghcr.io/${{ github.repository }}

--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-22.04
-    needs: integration-tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -42,64 +42,30 @@ jobs:
         shell: bash
         working-directory: ./.github/tests
 
-  build:
-    name: build (linux)
+  goreleaser:
     runs-on: ubuntu-22.04
     needs: integration-tests
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build artifact
-        run: make build
-      - name: Build docker artifact
-        run: make docker-build
-      - name: Compress artifact
-        run: tar -czvf spiffe-helper-${{ github.ref_name }}.tar.gz spiffe-helper
-      - name: Archive artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: spiffe-helper
-          path: |
-            spiffe-helper-${{ github.ref_name }}.tar.gz
-            spiffe-helper-image.tar
-
-  release:
-    runs-on: ubuntu-22.04
-    needs: build
-
-    permissions:
-      contents: write
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download archived artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: spiffe-helper
-          path: .
+          fetch-depth: 0
       - name: Log in to GHCR
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install regctl
-        uses: regclient/actions/regctl-installer@main
-      - name: Push docker image
-        run: ./.github/workflows/scripts/push-images.sh ${{ github.ref_name }}
-      - name: Create Release
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Create the release using the version number as the title
-        run: gh release create "${GITHUB_REF#refs/tags/}" ./spiffe-helper-${{ github.ref_name }}.tar.gz --title "${GITHUB_REF#refs/tags/}"
+          DOCKER_REPO: ghcr.io/${{ github.repository }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - binary: spiffe-helper
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/spiffe-helper
+
+archives:
+  - id: spiffe-helper
+    formats: [ 'tar.gz' ]
+    builds:
+      - spiffe-helper
+    # This name template makes the OS and Arch compatible with the results of `uname`
+    name_template: >-
+      spiffe-helper_{{- .Version}}_
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - README.md
+      - LICENSE
+    # Use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [ 'zip' ]
+
+dockers:
+  - id: spiffe-helper-amd64
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.DOCKER_REPO }}:{{ .Version}}-amd64"
+    use: buildx
+    dockerfile: Dockerfile-goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - id: spiffe-helper-arm64
+    goarch: arm64
+    image_templates:
+      - "{{ .Env.DOCKER_REPO }}:{{ .Version}}-arm64"
+    use: buildx
+    dockerfile: Dockerfile-goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "{{ .Env.DOCKER_REPO }}:{{ .Version}}"
+    image_templates:
+      - "{{ .Env.DOCKER_REPO }}:{{ .Version}}-amd64"
+      - "{{ .Env.DOCKER_REPO }}:{{ .Version}}-arm64"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static
+WORKDIR /
+COPY spiffe-helper /
+
+ENTRYPOINT ["/spiffe-helper"]
+CMD []


### PR DESCRIPTION
Switches to using go releaser to release binaries and docker containers. Works good in my fork. Keeping as draft to address these issues:
- Need to switch nightly build over to goreleaser
- Had to create a separate docker file for the go releaser workflow as it works best when the docker file just copies the build into the container.

partially addresses #240 
fixes #204 