### PR TITLE
Update to golangci-lint 2.1.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,12 @@
-run:
-  timeout: 10m
-
-issues:
-  exclude-dirs:
-    - testdata$
-    - test/mock
-  exclude-files:
-    - ".*\\.pb\\.go"
-
+version: "2"
 linters:
   enable:
     - bodyclose
     - dupword
     - durationcheck
     - errorlint
+    - goconst
     - gocritic
-    - gofmt
-    - goimports
     - gosec
     - intrange
     - misspell
@@ -25,12 +15,39 @@ linters:
     - nolintlint
     - prealloc
     - revive
+    - testifylint
+    - thelper
     - unconvert
     - unparam
     - wastedassign
     - whitespace
-
-linters-settings:
-  revive:
-    # minimal confidence for issues, default is 0.8
-    confidence: 0.0
+  settings:
+    revive:
+      confidence: 0
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - .*\.pb\.go
+      - testdata$
+      - test/mock
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*\.pb\.go
+      - testdata$
+      - test/mock
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ else
 endif
 go_path := PATH="$(go_bin_dir):$(PATH)"
 
-golangci_lint_version = v1.64.8
+golangci_lint_version = v2.1.6
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 golangci_lint_cache = $(golangci_lint_dir)/cache
@@ -135,7 +135,7 @@ $(golangci_lint_bin): | go-check
 	$(E)rm -rf $(dir $(golangci_lint_dir))
 	$(E)mkdir -p $(golangci_lint_dir)
 	$(E)mkdir -p $(golangci_lint_cache)
-	$(E)GOBIN=$(golangci_lint_dir) $(go_path) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_lint_version)
+	$(E)curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(golangci_lint_dir) $(golangci_lint_version)
 
 #############################################################################
 # Utility functions and targets

--- a/cmd/spiffe-helper/config/config.go
+++ b/cmd/spiffe-helper/config/config.go
@@ -144,7 +144,7 @@ func (c *Config) ValidateConfig(log logrus.FieldLogger) error {
 	}
 
 	if c.PIDFilename != "" && c.RenewSignal == "" {
-		return errors.New("Must specify renew_signal when using pid_file_name")
+		return errors.New("must specify renew_signal when using pid_file_name")
 	}
 
 	x509Enabled, err := validateX509Config(c)

--- a/cmd/spiffe-helper/config/config_test.go
+++ b/cmd/spiffe-helper/config/config_test.go
@@ -164,7 +164,7 @@ func TestValidateConfig(t *testing.T) {
 				PIDFilename: "pidfile",
 				RenewSignal: "",
 			},
-			expectError: "Must specify renew_signal when using pid_file_name",
+			expectError: "must specify renew_signal when using pid_file_name",
 			skipWindows: true,
 		},
 		{
@@ -333,7 +333,7 @@ func TestDefaultAgentAddress(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assert.Equal(t, config.AgentAddress, tt.expectedAgentAddress)
+			assert.Equal(t, tt.expectedAgentAddress, config.AgentAddress)
 
 			if tt.envSPIREAgentAddress != "" && tt.envSPIFFEEndpointSocket == "" {
 				require.NotNil(t, hook.LastEntry())
@@ -368,15 +368,15 @@ func TestNewSidecarConfig(t *testing.T) {
 	assert.Equal(t, config.IncludeFederatedDomains, sidecarConfig.IncludeFederatedDomains)
 
 	// Ensure JWT Config was populated correctly
-	require.Equal(t, len(config.JWTSVIDs), len(sidecarConfig.JWTSVIDs))
+	require.Len(t, sidecarConfig.JWTSVIDs, len(config.JWTSVIDs))
 	for i := range config.JWTSVIDs {
 		assert.Equal(t, config.JWTSVIDs[i].JWTAudience, sidecarConfig.JWTSVIDs[i].JWTAudience)
 		assert.Equal(t, config.JWTSVIDs[i].JWTSVIDFilename, sidecarConfig.JWTSVIDs[i].JWTSVIDFilename)
 	}
 
 	// Ensure empty fields were not populated
-	assert.Equal(t, "", sidecarConfig.SVIDFilename)
-	assert.Equal(t, "", sidecarConfig.RenewSignal)
+	assert.Empty(t, sidecarConfig.SVIDFilename)
+	assert.Empty(t, sidecarConfig.RenewSignal)
 }
 
 func TestDaemonModeFlag(t *testing.T) {
@@ -394,5 +394,5 @@ func TestDaemonModeFlag(t *testing.T) {
 
 	config.ParseConfigFlagOverrides(*daemonModeFlag, daemonModeFlagName)
 	require.NotNil(t, config.DaemonMode)
-	assert.Equal(t, false, *config.DaemonMode)
+	assert.False(t, *config.DaemonMode)
 }

--- a/pkg/disk/json_test.go
+++ b/pkg/disk/json_test.go
@@ -131,6 +131,8 @@ func TestWriteJWTSVIDWithHint(t *testing.T) {
 
 // Generate generates a signed string token
 func generateToken(tb testing.TB, claims jwt.Claims, signer crypto.Signer, keyID string) string {
+	tb.Helper()
+
 	// Get signer algorithm
 	alg, err := getSignerAlgorithm(signer)
 	require.NoError(tb, err)

--- a/pkg/sidecar/sidecar_posix_test.go
+++ b/pkg/sidecar/sidecar_posix_test.go
@@ -276,7 +276,7 @@ func TestSidecar_TestCmdRunsLongRunning(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	require.Equal(t, true, s.sidecar.processRunning)
+	require.True(t, s.sidecar.processRunning)
 	firstPid := s.sidecar.process.Pid
 
 	// There should be no signal sent to the test helper on the first iteration
@@ -289,7 +289,7 @@ func TestSidecar_TestCmdRunsLongRunning(t *testing.T) {
 	case forwardedSignal := <-sigListener:
 		// No signal should be delivered on the first iteration, since the
 		// helper was just launched.
-		require.Fail(t, "unexpected signal %s", SignalName(forwardedSignal.(syscall.Signal)))
+		require.Fail(t, "Test failed", "unexpected signal %s", SignalName(forwardedSignal.(syscall.Signal)))
 	case <-ctx.Done():
 		require.NoError(t, ctx.Err())
 	}
@@ -303,7 +303,7 @@ func TestSidecar_TestCmdRunsLongRunning(t *testing.T) {
 		s.MockUpdateX509Certificate(ctx, t, svid)
 
 		// Command is still running
-		require.Equal(t, true, s.sidecar.processRunning)
+		require.True(t, s.sidecar.processRunning)
 
 		// On the second or later iteration, we should have received a signal
 		// from the test helper. No signal is delivered on the first iteration
@@ -325,7 +325,7 @@ func TestSidecar_TestCmdRunsLongRunning(t *testing.T) {
 		}
 
 		// Command started and is still running
-		require.Equal(t, true, s.sidecar.processRunning)
+		require.True(t, s.sidecar.processRunning)
 
 		if firstPid == -1 {
 			firstPid = s.sidecar.process.Pid

--- a/pkg/sidecar/util_test.go
+++ b/pkg/sidecar/util_test.go
@@ -58,6 +58,8 @@ type sidecarTest struct {
 // MockUpdateX509Certificate to simulate the workload API server sending a
 // response.
 func newSidecarTest(t *testing.T) *sidecarTest {
+	t.Helper()
+
 	log, _ := test.NewNullLogger()
 	s := &sidecarTest{
 		rootCA: spiffetest.NewCA(t),
@@ -108,6 +110,8 @@ func newSidecarTest(t *testing.T) *sidecarTest {
 // Any pending signals must have been delivered, and any running processes
 // must have exited.
 func (s *sidecarTest) Close(t *testing.T) {
+	t.Helper()
+
 	err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return err != nil
 	}, func() (err error) {
@@ -128,6 +132,8 @@ func (s *sidecarTest) Close(t *testing.T) {
 // Trigger a certificate update on the sidecar instance to the passed new SVID.
 // The golang context passed should have a timeout set to avoid hanging tests.
 func (s *sidecarTest) MockUpdateX509Certificate(ctx context.Context, t *testing.T, svid testX509SVID) {
+	t.Helper()
+
 	// Send the new SVID to the sidecar
 	s.watcher.OnX509ContextUpdate(svid.x509Context())
 	// and wait for the sidecar to process it
@@ -163,6 +169,8 @@ type testX509SVID struct {
 // Create a single svid without intermediate, as if the workload api server
 // issued a cert from the specified root CA.
 func newTestX509SVID(t *testing.T, rootCA *spiffetest.CA) testX509SVID {
+	t.Helper()
+
 	spiffeID, err := spiffeid.FromString(exampleSpiffeID)
 	require.NoError(t, err)
 	svidChain, svidKey := rootCA.CreateX509SVID(spiffeID.String())

--- a/pkg/util/task.go
+++ b/pkg/util/task.go
@@ -28,7 +28,7 @@ func RunTasks(ctx context.Context, tasks ...func(context.Context) error) error {
 	runTask := func(task func(context.Context) error) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack())) //nolint: revive // newlines are intentional
+				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack())) //nolint: staticcheck, revive // newlines are intentional
 			}
 			wg.Done()
 		}()
@@ -68,7 +68,7 @@ func SerialRun(tasks ...func(context.Context) error) func(ctx context.Context) e
 	return func(ctx context.Context) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack())) //nolint: revive // newlines are intentional
+				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack())) //nolint: staticcheck, revive // newlines are intentional
 			}
 		}()
 

--- a/pkg/util/task_test.go
+++ b/pkg/util/task_test.go
@@ -114,6 +114,8 @@ func testRunTasks(ctx context.Context, tasks ...func(context.Context) error) cha
 }
 
 func assertErrorChan(t *testing.T, ch chan error, expected error) {
+	t.Helper()
+
 	timer := time.NewTimer(time.Second)
 	select {
 	case <-timer.C:
@@ -126,6 +128,8 @@ func assertErrorChan(t *testing.T, ch chan error, expected error) {
 }
 
 func assertErrorChanContains(t *testing.T, ch chan error, contains string) {
+	t.Helper()
+
 	timer := time.NewTimer(time.Second)
 	select {
 	case <-timer.C:

--- a/test/spiffetest/ca.go
+++ b/test/spiffetest/ca.go
@@ -22,6 +22,8 @@ type CA struct {
 }
 
 func NewCA(tb testing.TB) *CA {
+	tb.Helper()
+
 	cert, key := CreateCACertificate(tb, nil, nil)
 	return &CA{
 		tb:   tb,
@@ -54,6 +56,8 @@ func (ca *CA) Roots() []*x509.Certificate {
 }
 
 func CreateCACertificate(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
+	tb.Helper()
+
 	now := time.Now()
 	serial := NewSerial(tb)
 
@@ -76,6 +80,8 @@ func CreateCACertificate(tb testing.TB, parent *x509.Certificate, parentKey cryp
 }
 
 func CreateX509SVID(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer, spiffeID string) (*x509.Certificate, crypto.Signer) {
+	tb.Helper()
+
 	now := time.Now()
 	serial := NewSerial(tb)
 
@@ -96,6 +102,8 @@ func CreateX509SVID(tb testing.TB, parent *x509.Certificate, parentKey crypto.Si
 }
 
 func CreateCertificate(tb testing.TB, tmpl, parent *x509.Certificate, pub, priv interface{}) *x509.Certificate {
+	tb.Helper()
+
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, priv)
 	require.NoError(tb, err)
 	cert, err := x509.ParseCertificate(certDER)
@@ -104,6 +112,8 @@ func CreateCertificate(tb testing.TB, tmpl, parent *x509.Certificate, pub, priv 
 }
 
 func NewSerial(tb testing.TB) *big.Int {
+	tb.Helper()
+
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	require.NoError(tb, err)

--- a/test/spiffetest/keys.go
+++ b/test/spiffetest/keys.go
@@ -14,6 +14,8 @@ import (
 
 // NewEC256Key returns an ECDSA key over the P256 curve
 func NewEC256Key(tb testing.TB) *ecdsa.PrivateKey {
+	tb.Helper()
+
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(tb, err)
 	return key


### PR DESCRIPTION
- Update to latest linter 2.1.6
- Switch to binary install (recommended by goalngci-lint)
- Fix linter errors