### PR TITLE
fix: bump go version to fix CVE issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiffe/spiffe-helper
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/hashicorp/hcl v1.0.1-vault-7


### PR DESCRIPTION
build the image

```console
$ docker buildx build --platform linux/arm64 --build-arg go_version=1.24.5 -f Dockerfile -t upmdev.azurecr.io/spiffe-helper/spiffe-helper:local . --push
```

check the CVE issues

```console
$ grype upmdev.azurecr.io/spiffe-helper/spiffe-helper:local
 ✔ Pulled image
 ✔ Loaded image                                                                                                                              upmdev.azurecr.io/spiffe-helper/spiffe-helper:local
 ✔ Parsed image                                                                                                          sha256:31ae992b5f7478c6ed6718ed88f17830944c99848dbc8d7ad20ed15c84a4a0f6
 ✔ Cataloged contents                                                                                                           436779ae271c6849585dcc44c4cd508887c268833fe436447b9db17327af9f7d
   ├── ✔ Packages                        [32 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File metadata                   [942 locations]
   └── ✔ File digests                    [942 files]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
A newer version of grype is available for download: 0.96.0 (installed version is 0.94.0)
```